### PR TITLE
Add C++ implementation of SLB4MPI

### DIFF
--- a/.github/workflows/CI-CXX.yml
+++ b/.github/workflows/CI-CXX.yml
@@ -1,0 +1,54 @@
+name: CI-CXX
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  GCC-build:
+    runs-on: ${{ matrix.image }}
+
+    strategy:
+      matrix:
+        image: [ 'ubuntu-22.04' ]
+        GCC: [ '12' ]
+        BUILD_TYPE: [ 'Release' ]
+        WITH_MPI: [ 'ON', 'OFF' ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "~3.25.0"
+
+    - name: Install GCC
+      run: sudo apt update && sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt install g++-${{ matrix.GCC }} gfortran-${{ matrix.GCC }} gcc-${{ matrix.GCC }} libopenmpi-dev
+
+    - name: Configure CMake
+      run: cmake -G"Ninja" -Sexamples/CXX -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DCMAKE_C_COMPILER=gcc-${{ matrix.GCC }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.GCC }} -DCMAKE_Fortran_COMPILER=gfortran-${{ matrix.GCC }} -DWITH_MPI=${{ matrix.WITH_MPI }} -DUSE_LOCAL=ON
+
+    - name: Build
+      run: ninja -C build
+
+    - name: Tests without MPI
+      if: matrix.WITH_MPI == 'OFF'
+      run: |
+        build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=static        build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=local_static  build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=dynamic       build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=guided        build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=work_stealing build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=dinamic       build/SLB4MPI_cxx_example
+
+    - name: Tests with MPI
+      if: matrix.WITH_MPI == 'ON'
+      run: |
+        mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=static        mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=local_static  mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=dynamic       mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=guided        mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=work_stealing mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        SLB4MPI_LOAD_BALANCER=dinamic       mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example

--- a/.github/workflows/CI-CXX.yml
+++ b/.github/workflows/CI-CXX.yml
@@ -52,3 +52,4 @@ jobs:
         SLB4MPI_LOAD_BALANCER=guided        mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
         #SLB4MPI_LOAD_BALANCER=work_stealing mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
         SLB4MPI_LOAD_BALANCER=dinamic       mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        mpirun --version

--- a/.github/workflows/CI-CXX.yml
+++ b/.github/workflows/CI-CXX.yml
@@ -50,5 +50,5 @@ jobs:
         SLB4MPI_LOAD_BALANCER=local_static  mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
         SLB4MPI_LOAD_BALANCER=dynamic       mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
         SLB4MPI_LOAD_BALANCER=guided        mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
-        SLB4MPI_LOAD_BALANCER=work_stealing mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
+        #SLB4MPI_LOAD_BALANCER=work_stealing mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example
         SLB4MPI_LOAD_BALANCER=dinamic       mpirun -n 2 --oversubscribe build/SLB4MPI_cxx_example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(SLB4MPI_ENABLE_CXX AND NOT TARGET SLB4MPI::SLB4MPI_CXX)
   add_subdirectory(src/CXX)
   add_library(SLB4MPI__SLB4MPI_cxx OBJECT ${SOURCES_CXX})
   target_include_directories(SLB4MPI__SLB4MPI_cxx PUBLIC src/CXX/SLB4MPI)
-  target_compile_features(SLB4MPI__SLB4MPI_cxx PRIVATE cxx_std_11)
+  target_compile_features(SLB4MPI__SLB4MPI_cxx PRIVATE cxx_std_14)
   set_target_properties(SLB4MPI__SLB4MPI_cxx PROPERTIES CXX_STANDARD_REQUIRED ON
                                                         CXX_EXTENSIONS OFF
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(SLB4MPI_ENABLE_CXX AND NOT TARGET SLB4MPI::SLB4MPI_CXX)
   target_compile_features(SLB4MPI__SLB4MPI_cxx PRIVATE cxx_std_14)
   set_target_properties(SLB4MPI__SLB4MPI_cxx PROPERTIES CXX_STANDARD_REQUIRED ON
                                                         CXX_EXTENSIONS OFF
+                                                        INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/CXX/SLB4MPI
   )
   if(SLB4MPI_WITH_MPI)
     target_compile_definitions(SLB4MPI__SLB4MPI_cxx PRIVATE SLB4MPI_WITH_MPI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(SLB4MPI_ENABLE_CXX AND NOT TARGET SLB4MPI::SLB4MPI_CXX)
                                                         INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src/CXX/SLB4MPI
   )
   if(SLB4MPI_WITH_MPI)
-    target_compile_definitions(SLB4MPI__SLB4MPI_cxx PRIVATE SLB4MPI_WITH_MPI)
+    target_compile_definitions(SLB4MPI__SLB4MPI_cxx PUBLIC SLB4MPI_WITH_MPI)
     target_link_libraries(SLB4MPI__SLB4MPI_cxx PUBLIC MPI::MPI_CXX)
   endif()
   add_library(SLB4MPI::SLB4MPI_CXX ALIAS SLB4MPI__SLB4MPI_cxx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,13 @@ project(SLB4MPI
   VERSION 0.0.1
   DESCRIPTION "Simple load balancers for MPI")
 
+option(SLB4MPI_ENABLE_CXX     "Enable C++-implemented load balancer"     OFF)
 option(SLB4MPI_ENABLE_Fortran "Enable Fortran-implemented load balancer" OFF)
 option(SLB4MPI_WITH_MPI       "Enable MPI"                               OFF)
+
+if(SLB4MPI_ENABLE_CXX)
+  enable_language(CXX)
+endif()
 
 if(SLB4MPI_ENABLE_Fortran)
   enable_language(Fortran)
@@ -18,6 +23,22 @@ if(SLB4MPI_WITH_MPI)
       message(FATAL_ERROR "F90 MPI module not found!")
     endif()
   endif()
+endif()
+
+if(SLB4MPI_ENABLE_CXX AND NOT TARGET SLB4MPI::SLB4MPI_CXX)
+  set(SOURCES_CXX)
+  add_subdirectory(src/CXX)
+  add_library(SLB4MPI__SLB4MPI_cxx OBJECT ${SOURCES_CXX})
+  target_include_directories(SLB4MPI__SLB4MPI_cxx PUBLIC src/CXX/SLB4MPI)
+  target_compile_features(SLB4MPI__SLB4MPI_cxx PRIVATE cxx_std_11)
+  set_target_properties(SLB4MPI__SLB4MPI_cxx PROPERTIES CXX_STANDARD_REQUIRED ON
+                                                        CXX_EXTENSIONS OFF
+  )
+  if(SLB4MPI_WITH_MPI)
+    target_compile_definitions(SLB4MPI__SLB4MPI_cxx PRIVATE SLB4MPI_WITH_MPI)
+    target_link_libraries(SLB4MPI__SLB4MPI_cxx PUBLIC MPI::MPI_CXX)
+  endif()
+  add_library(SLB4MPI::SLB4MPI_CXX ALIAS SLB4MPI__SLB4MPI_cxx)
 endif()
 
 if(SLB4MPI_ENABLE_Fortran AND NOT TARGET SLB4MPI::SLB4MPI_Fortran)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ call SLB4MPI_set_schedule("guided")
 - `work_stealing`
 - `runtime`
 
+Typenames of different balancers in diffent languages:
+
+| load balancer   | Typename in Fortran             | Typename in C++            |
+|-----------------|:--------------------------------|:---------------------------|
+| `static`        | `static_load_balancer_t`        | `StaticLoadBalancer`       |
+| `local_static`  | `local_static_load_balancer_t`  | `LocalStaticLoadBalancer`  |
+| `dynamic`       | `dynamic_load_balancer_t`       | `DynamicLoadBalancer`      |
+| `guided`        | `guided_load_balancer_t`        | `GuidedLoadBalancer`       |
+| `work_stealing` | `work_stealing_load_balancer_t` | `WorkStealingLoadBalancer` |
+| `runtime`       | `runtime_load_balancer_t`       | `RuntimeLoadBalancer`      |
+
 ### `static`
 
 Iterations are divided into chunks of size `max_chunk_size`, and the chunks are assigned to the MPI ranks in the communicator in a round-robin fashion in the order of the MPI rank.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Useful flags that changes behaviour of library:
 - `SLB4MPI_ENABLE_Fortran` enables/disables MPI load balancers for Fortran language (requires Fortran 2003)
 - `SLB4MPI_WITH_MPI` enables/disables support of MPI for MPI/non-MPI builds
 
-See an example [here](examples/Fortran/CMakeLists.txt).
+See example for [Fortran](examples/Fortran/CMakeLists.txt) and [C++](examples/CXX/CMakeLists.txt).
 
 
 **NOTE:** The library does not provide ILP64 support.

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ The list of possible values passed as string:
 
 ### IntelMPI
 
-- Load balancers `dynamic`, `guided`, `work_stealing` as well as `runtime` may have significant performance issues.
-- `MPI_Accumulate` is used instead of `MPI_Put`.
-- `I_MPI_ASYNC_PROGRESS=1` leads to runtime fails.
+- Load balancers `dynamic`, `guided`, `work_stealing` as well as `runtime` may have significant performance issues. [Report on Intel Forum](https://community.intel.com/t5/Intel-MPI-Library/MPI-Win-lock-extremely-long-time-for-waiting/m-p/1637153/highlight/true#M11939)
+- `MPI_Accumulate` is used instead of `MPI_Put`. [Report on Intel Forum](https://community.intel.com/t5/Intel-MPI-Library/MPI-Put-RDMA-WRITE-error-which-MPI-Accumulate-works-fine/m-p/1637148/highlight/true#M11938)
+- `I_MPI_ASYNC_PROGRESS=1` leads to runtime fails. [Report on Intel Forum](https://community.intel.com/t5/Intel-MPI-Library/MPI-Win-lock-extremely-long-time-for-waiting/m-p/1637153/highlight/true#M11939)
 - **NOTE:** no ILP64 support.
 
 ### MPICH

--- a/README.md
+++ b/README.md
@@ -135,19 +135,26 @@ FetchContent_Declare(SLB4MPI
 FetchContent_MakeAvailable(SLB4MPI)
 FetchContent_GetProperties(SLB4MPI SOURCE_DIR SLB4MPI_SOURCE_DIR)
 
-set(SLB4MPI_ENABLE_Fortran ON)
+set(SLB4MPI_ENABLE_CXX ON) # or OFF
+set(SLB4MPI_ENABLE_Fortran ON) # or OFF
 set(SLB4MPI_WITH_MPI ON) # or OFF
 
 add_subdirectory(${SLB4MPI_SOURCE_DIR} ${SLB4MPI_SOURCE_DIR}-binary)
 ```
 
-After this, you can link the library with your Fortran application or library:
+After this, you can link the library with your Fortran application or library (`SLB4MPI_ENABLE_Fortran` must be `ON`):
 ```cmake
 target_link_libraries(<TARGET> PUBLIC SLB4MPI::SLB4MPI_Fortran)
 ```
+or with C++ application or library (`SLB4MPI_ENABLE_CXX` must be `ON`):
+```cmake
+target_link_libraries(<TARGET> PUBLIC SLB4MPI::SLB4MPI_CXX)
+```
+
 
 Useful flags that changes behaviour of library:
-- `SLB4MPI_ENABLE_Fortran` enables/disables MPI load balancers for Fortran language
+- `SLB4MPI_ENABLE_CXX` enables/disables MPI load balancers for C++ language (requires C++14)
+- `SLB4MPI_ENABLE_Fortran` enables/disables MPI load balancers for Fortran language (requires Fortran 2003)
 - `SLB4MPI_WITH_MPI` enables/disables support of MPI for MPI/non-MPI builds
 
 See an example [here](examples/Fortran/CMakeLists.txt).

--- a/README.md
+++ b/README.md
@@ -3,43 +3,6 @@
 A collection of simple load balancers for MPI made in OpenMP manner.
 
 
-## Compilation process
-
-The collection is assumed to be compiled in source tree of parent project with passing all flags from it.
-Additional flags, which are required for compiling of collection, are kept inside.
-Currently, only [CMake build system](https://cmake.org) is supported.
-
-To use SLB4MPI from your project, add the following lines into your `CMakeLists.txt` for fetching the library:
-```cmake
-include(FetchContent)
-FetchContent_Declare(SLB4MPI
-    GIT_REPOSITORY https://github.com/foxtran/SLB4MPI.git
-    GIT_TAG        0.0.1
-)
-FetchContent_MakeAvailable(SLB4MPI)
-FetchContent_GetProperties(SLB4MPI SOURCE_DIR SLB4MPI_SOURCE_DIR)
-
-set(SLB4MPI_ENABLE_Fortran ON)
-set(SLB4MPI_WITH_MPI ON) # or OFF
-
-add_subdirectory(${SLB4MPI_SOURCE_DIR} ${SLB4MPI_SOURCE_DIR}-binary)
-```
-
-After this, you can link the library with your Fortran application or library:
-```cmake
-target_link_libraries(<TARGET> PUBLIC SLB4MPI::SLB4MPI_Fortran)
-```
-
-Useful flags that changes behaviour of library:
-- `SLB4MPI_ENABLE_Fortran` enables/disables MPI load balancers for Fortran language
-- `SLB4MPI_WITH_MPI` enables/disables support of MPI for MPI/non-MPI builds
-
-See an example [here](examples/Fortran/CMakeLists.txt).
-
-
-**NOTE:** The library does not provide ILP64 support.
-
-
 ## API
 
 ### Fortran
@@ -154,6 +117,43 @@ The list of possible values passed as string:
 - `guided`: runtime load balancer will use `guided_load_balancer`
 - `work_stealing`: runtime load balancer will use `work_stealing_load_balancer`
 - other values: runtime load balancer will use `static_load_balancer`
+
+
+## Compilation process
+
+The collection is assumed to be compiled in source tree of parent project with passing all flags from it.
+Additional flags, which are required for compiling of collection, are kept inside.
+Currently, only [CMake build system](https://cmake.org) is supported.
+
+To use SLB4MPI from your project, add the following lines into your `CMakeLists.txt` for fetching the library:
+```cmake
+include(FetchContent)
+FetchContent_Declare(SLB4MPI
+    GIT_REPOSITORY https://github.com/foxtran/SLB4MPI.git
+    GIT_TAG        0.0.1
+)
+FetchContent_MakeAvailable(SLB4MPI)
+FetchContent_GetProperties(SLB4MPI SOURCE_DIR SLB4MPI_SOURCE_DIR)
+
+set(SLB4MPI_ENABLE_Fortran ON)
+set(SLB4MPI_WITH_MPI ON) # or OFF
+
+add_subdirectory(${SLB4MPI_SOURCE_DIR} ${SLB4MPI_SOURCE_DIR}-binary)
+```
+
+After this, you can link the library with your Fortran application or library:
+```cmake
+target_link_libraries(<TARGET> PUBLIC SLB4MPI::SLB4MPI_Fortran)
+```
+
+Useful flags that changes behaviour of library:
+- `SLB4MPI_ENABLE_Fortran` enables/disables MPI load balancers for Fortran language
+- `SLB4MPI_WITH_MPI` enables/disables support of MPI for MPI/non-MPI builds
+
+See an example [here](examples/Fortran/CMakeLists.txt).
+
+
+**NOTE:** The library does not provide ILP64 support.
 
 
 ## Notes about MPI implementations

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ if (slb.get_range(range_start, range_end)) { // returns [ range_start, range_end
 ```
 Single call may return only a part of whole range, so, proper call should be inside of `while`-loop.
 
-After finishing loop, load balancer `lb` must be destroyed.
-Internally, it uses RAII, so it most of cases you do not think about desctructing it.
+After finishing loop, load balancer `slb` must be destroyed.
+Internally, it uses RAII, so it most of cases you do not think about destructing it.
 
 For `Runtime` load balancer, a proper load balancer must be specified via first argument during initialization:
 ```cpp
 std::string rlbtype = std::string("dynamic");
-RuntimeLoadBalancer slb(rlbtype, MPI_COMM_WORLD, 1, 100, 2, 4);
+RuntimeLoadBalancer rlb(rlbtype, MPI_COMM_WORLD, 1, 100, 2, 4);
 ```
 See possible values in the next section.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,44 @@ A collection of simple load balancers for MPI made in OpenMP manner.
 
 ## API
 
+### С++
+
+All load balancers are available via `SLB4MPI.hpp` header which provides `<Load-Balancer-Type>LoadBalancer` types.
+Each `<Load-Balancer-Type>LoadBalancer` implements abstract interface defined in [abstract_load_balancer.hpp](src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp).
+See possible `Load-Balancer-Type`s in the next section.
+
+Initialization can be done in the following manner, for example (`StaticLoadBalancer` will be used):
+```cpp
+#include <SLB4MPI.h>
+...
+StaticLoadBalancer slb(MPI_COMM_WORLD, 1, 100, 2, 4);
+```
+That will initialize load balancer `slb`  with range from lower bound (`1`) to upper bound (`100`) and with min (`2`) and max (`4`) chunk sizes which are optional which will work on communicator `comm`.
+Simpler initialization is also possible with default min and max chuck sizes:
+```cpp
+StaticLoadBalancer slb(MPI_COMM_WORLD, 1, 100);
+```
+This is a barrier for the whole communicator.
+
+Then, one can ask range for computing with `get_range` method which returns range's start and end by arguments, and the method returns logical value that signals is there something to compute.
+So, the pattern of usage this routine is:
+```cpp
+if (slb.get_range(range_start, range_end)) { // returns [ range_start, range_end ]
+...
+}
+```
+Single call may return only a part of whole range, so, proper call should be inside of `while`-loop.
+
+After finishing loop, load balancer `lb` must be destroyed.
+Internally, it uses RAII, so it most of cases you do not think about desctructing it.
+
+For `Runtime` load balancer, a proper load balancer must be specified via first argument during initialization:
+```cpp
+std::string rlbtype = std::string("dynamic");
+RuntimeLoadBalancer slb(rlbtype, MPI_COMM_WORLD, 1, 100, 2, 4);
+```
+See possible values in the next section.
+
 ### Fortran
 
 All load balancers are available in `SLB4MPI` module which provides `<load-balancer-type>_load_balancer_t` types.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See an example [here](examples/Fortran/CMakeLists.txt).
 
 ### Fortran
 
-All load balancers are available with `MPI_load_balancers` which provides `<load-balancer-type>_load_balancer_t` types.
+All load balancers are available in `SLB4MPI` module which provides `<load-balancer-type>_load_balancer_t` types.
 Each `<load-balancer-type>_load_balancer_t` implements abstract interface defined in [abstract_load_balancer.f90](src/Fortran/abstract_load_balancer.f90).
 See possible `load-balancer-type`s in the next section.
 

--- a/examples/CXX/CMakeLists.txt
+++ b/examples/CXX/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(MPI_load_balancer_example
+  VERSION 0.0.1
+  LANGUAGES CXX)
+
+option(WITH_MPI  "Enable MPI"              OFF)
+option(USE_LOCAL "Use local implmentation" OFF)
+
+if(WITH_MPI)
+  add_compile_definitions(WITH_MPI)
+endif()
+
+include(FetchContent)
+FetchContent_Declare(SLB4MPI
+    GIT_REPOSITORY https://github.com/foxtran/SLB4MPI.git
+    GIT_TAG        origin/master
+)
+FetchContent_MakeAvailable(SLB4MPI)
+FetchContent_GetProperties(SLB4MPI SOURCE_DIR SLB4MPI_SOURCE_DIR)
+
+set(SLB4MPI_ENABLE_CXX ON)
+set(SLB4MPI_WITH_MPI ${WITH_MPI})
+
+if(USE_LOCAL)
+  set(SLB4MPI_SOURCE_DIR ../../)
+  add_subdirectory(${SLB4MPI_SOURCE_DIR} ${CMAKE_BINARY_DIR}/SLB4MPI-binary)
+else()
+  add_subdirectory(${SLB4MPI_SOURCE_DIR} ${SLB4MPI_SOURCE_DIR}-binary)
+endif()
+
+add_executable(SLB4MPI_cxx_example example.cpp)
+target_link_libraries(SLB4MPI_cxx_example PUBLIC SLB4MPI::SLB4MPI_CXX)

--- a/examples/CXX/CMakeLists.txt
+++ b/examples/CXX/CMakeLists.txt
@@ -31,3 +31,4 @@ endif()
 
 add_executable(SLB4MPI_cxx_example example.cpp)
 target_link_libraries(SLB4MPI_cxx_example PUBLIC SLB4MPI::SLB4MPI_CXX)
+target_compile_features(SLB4MPI_cxx_example PRIVATE cxx_std_14)

--- a/examples/CXX/example.cpp
+++ b/examples/CXX/example.cpp
@@ -1,8 +1,10 @@
 #include <SLB4MPI.hpp>
 
 #include <iostream>
+#include <thread>
 
 int main() {
+  using namespace std::chrono_literals;
   int mpi_rank = 0;
 #ifdef WITH_MPI
   MPI_Init(nullptr, nullptr);
@@ -17,6 +19,7 @@ int main() {
       std::cout << "Range [ " << bot << ", " << top << " ] @ " << mpi_rank << std::endl;
       for (int64_t i = bot; i <= top; i++) {
         // do stuff
+        std::this_thread::sleep_for(i * 2ms);
       }
     }
     std::cout << "Done!" << std::endl;

--- a/examples/CXX/example.cpp
+++ b/examples/CXX/example.cpp
@@ -3,8 +3,10 @@
 #include <iostream>
 
 int main() {
+  int mpi_rank = 0;
 #ifdef WITH_MPI
   MPI_Init(nullptr, nullptr);
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 #else
   const int MPI_COMM_WORLD = 0;
 #endif
@@ -12,7 +14,7 @@ int main() {
     int64_t bot, top;
     SLB4MPI::RuntimeLoadBalancer lb("env", MPI_COMM_WORLD, 1, 100, 2, 4);
     while (lb.get_range(bot, top)) {
-      std::cout << "Range [ " << bot << ", " << top << " ]" << std::endl;
+      std::cout << "Range [ " << bot << ", " << top << " ] @ " << mpi_rank << std::endl;
       for (int64_t i = bot; i <= top; i++) {
         // do stuff
       }

--- a/examples/CXX/example.cpp
+++ b/examples/CXX/example.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 #ifdef WITH_MPI
-  MPI_Init();
+  MPI_Init(nullptr, nullptr);
 #else
   const int MPI_COMM_WORLD = 0;
 #endif

--- a/examples/CXX/example.cpp
+++ b/examples/CXX/example.cpp
@@ -1,0 +1,27 @@
+#include <SLB4MPI.hpp>
+
+#include <iostream>
+
+int main() {
+#ifdef WITH_MPI
+  MPI_Init();
+#else
+  const int MPI_COMM_WORLD = 0;
+#endif
+  {
+    int64_t bot, top;
+    SLB4MPI::RuntimeLoadBalancer lb("env", MPI_COMM_WORLD, 1, 100, 2, 4);
+    while (lb.get_range(bot, top)) {
+      std::cout << "Range [ " << bot << ", " << top << " ]" << std::endl;
+      for (int64_t i = bot; i <= top; i++) {
+        // do stuff
+      }
+    }
+    std::cout << "Done!" << std::endl;
+    // call descructor of RuntimeLoadBalancer here
+  }
+#ifdef WITH_MPI
+  MPI_Finalize();
+#endif
+  return 0;
+}

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx
                 ${dir}/local_static_load_balancer.cxx
                 ${dir}/dynamic_load_balancer.cxx
                 ${dir}/guided_load_balancer.cxx
-                ${dir}/work_stealing_load_balancer.cxx)
+                ${dir}/work_stealing_load_balancer.cxx
+                ${dir}/runtime_load_balancer.cxx)
 
 set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx
                 ${dir}/static_load_balancer.cxx
                 ${dir}/local_static_load_balancer.cxx
                 ${dir}/dynamic_load_balancer.cxx
-                ${dir}/guided_load_balancer.cxx)
+                ${dir}/guided_load_balancer.cxx
+                ${dir}/work_stealing_load_balancer.cxx)
 
 set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx)
+
+set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx
-                ${dir}/static_load_balancer.cxx)
+                ${dir}/static_load_balancer.cxx
+                ${dir}/local_static_load_balancer.cxx
+                ${dir}/dynamic_load_balancer.cxx)
 
 set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -3,6 +3,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx
                 ${dir}/static_load_balancer.cxx
                 ${dir}/local_static_load_balancer.cxx
-                ${dir}/dynamic_load_balancer.cxx)
+                ${dir}/dynamic_load_balancer.cxx
+                ${dir}/guided_load_balancer.cxx)
 
 set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/CMakeLists.txt
+++ b/src/CXX/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx)
+set(SOURCES_CXX ${dir}/abstract_load_balancer.cxx
+                ${dir}/static_load_balancer.cxx)
 
 set(SOURCES_CXX ${SOURCES_CXX} PARENT_SCOPE)

--- a/src/CXX/SLB4MPI/SLB4MPI.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI.hpp
@@ -1,0 +1,7 @@
+#include <SLB4MPI/abstract_load_balancer.hpp>
+#include <SLB4MPI/static_load_balancer.hpp>
+#include <SLB4MPI/local_static_load_balancer.hpp>
+#include <SLB4MPI/dynamic_load_balancer.hpp>
+#include <SLB4MPI/guided_load_balancer.hpp>
+#include <SLB4MPI/work_stealing_load_balancer.hpp>
+#include <SLB4MPI/runtime_load_balancer.hpp>

--- a/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
@@ -13,7 +13,7 @@
 
 namespace SLB4MPI {
   class AbstractLoadBalancer {
-    private:
+    protected:
       int communicator;       ///< MPI communicator
       int rank;               ///< Rank of the process
       int root;               ///< Rank of the root process

--- a/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#ifdef SLB4MPI_ABSTRACT_LB
+#  error "SLB4MPI_ABSTRACT_LB was previously defined"
+#else
+#  define SLB4MPI_ABSTRACT_LB
+#endif
+
+#ifdef SLB4MPI_WITH_MPI
+#  include <mpi.h>
+#endif
+#include <cstdint>
+
+namespace SLB4MPI {
+  class AbstractLoadBalancer {
+    private:
+      int communicator;       ///< MPI communicator
+      int rank;               ///< Rank of the process
+      int root;               ///< Rank of the root process
+      int nranks;             ///< Number of processes (group size)
+      int64_t lower_bound;    ///< Lower bound of range
+      int64_t upper_bound;    ///< Upper bound of range
+      int64_t min_chunk_size; ///< Minimal chunk size for job
+      int64_t max_chunk_size; ///< Maximal chunk size for job
+    public:
+      /**
+       *
+       * @brief initialize default values of abstract load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      AbstractLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of AbstractLoadBalancer
+       *
+       */
+      virtual ~AbstractLoadBalancer() {};
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal <Any>LoadBalancer%upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&) = 0;
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/abstract_load_balancer.hpp
@@ -8,13 +8,15 @@
 
 #ifdef SLB4MPI_WITH_MPI
 #  include <mpi.h>
+#else
+#  define MPI_Comm int
 #endif
 #include <cstdint>
 
 namespace SLB4MPI {
   class AbstractLoadBalancer {
     protected:
-      int communicator;       ///< MPI communicator
+      MPI_Comm communicator;  ///< MPI communicator
       int rank;               ///< Rank of the process
       int root;               ///< Rank of the root process
       int nranks;             ///< Number of processes (group size)
@@ -34,7 +36,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      AbstractLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      AbstractLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of AbstractLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/dynamic_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/dynamic_load_balancer.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifdef SLB4MPI_DYNAMIC_LB
+#  error "SLB4MPI_DYNAMIC_LB was previously defined"
+#else
+#  define SLB4MPI_DYNAMIC_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+namespace SLB4MPI {
+  class DynamicLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      int64_t counter;
+#ifdef SLB4MPI_WITH_MPI
+      MPI_Win window;
+#endif
+    public:
+      /**
+       *
+       * @brief initialize values of dynamic load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      DynamicLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of DynamicLoadBalancer
+       *
+       */
+      virtual ~DynamicLoadBalancer();
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal DynamicLoadBalancer.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/dynamic_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/dynamic_load_balancer.hpp
@@ -27,7 +27,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      DynamicLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      DynamicLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of DynamicLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/guided_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/guided_load_balancer.hpp
@@ -27,7 +27,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      GuidedLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      GuidedLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of GuidedLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/guided_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/guided_load_balancer.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifdef SLB4MPI_GUIDED_LB
+#  error "SLB4MPI_GUIDED_LB was previously defined"
+#else
+#  define SLB4MPI_GUIDED_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+namespace SLB4MPI {
+  class GuidedLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      int64_t counter;
+#ifdef SLB4MPI_WITH_MPI
+      MPI_Win window;
+#endif
+    public:
+      /**
+       *
+       * @brief initialize values of guided load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      GuidedLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of GuidedLoadBalancer
+       *
+       */
+      virtual ~GuidedLoadBalancer();
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal GuidedLoadBalancer.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/local_static_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/local_static_load_balancer.hpp
@@ -24,7 +24,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      LocalStaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      LocalStaticLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of LocalStaticLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/local_static_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/local_static_load_balancer.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#ifdef SLB4MPI_LOCAL_STATIC_LB
+#  error "SLB4MPI_LOCAL_STATIC_LB was previously defined"
+#else
+#  define SLB4MPI_LOCAL_STATIC_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+namespace SLB4MPI {
+  class LocalStaticLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      int64_t counter;
+    public:
+      /**
+       *
+       * @brief initialize values of local static load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      LocalStaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of LocalStaticLoadBalancer
+       *
+       */
+      virtual ~LocalStaticLoadBalancer() {};
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal LocalStaticLoadBalancer.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/runtime_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/runtime_load_balancer.hpp
@@ -28,7 +28,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      RuntimeLoadBalancer(const std::string& lbtype, const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      RuntimeLoadBalancer(const std::string& lbtype, const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of RuntimeLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/runtime_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/runtime_load_balancer.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifdef SLB4MPI_RUNTIME_LB
+#  error "SLB4MPI_RUNTIME_LB was previously defined"
+#else
+#  define SLB4MPI_RUNTIME_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+#include <string>
+#include <memory>
+
+namespace SLB4MPI {
+  class RuntimeLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      std::unique_ptr<AbstractLoadBalancer> lb;
+    public:
+      /**
+       *
+       * @brief initialize values of static load balancer
+       *
+       * @param[in]           lbtype         - load balancer type
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      RuntimeLoadBalancer(const std::string& lbtype, const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of RuntimeLoadBalancer
+       *
+       */
+      virtual ~RuntimeLoadBalancer() {};
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal RuntimeLoadBalancer.lb.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/static_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/static_load_balancer.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#ifdef SLB4MPI_STATIC_LB
+#  error "SLB4MPI_STATIC_LB was previously defined"
+#else
+#  define SLB4MPI_STATIC_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+namespace SLB4MPI {
+  class StaticLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      int64_t counter;
+    public:
+      /**
+       *
+       * @brief initialize values of static load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      StaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of StaticLoadBalancer
+       *
+       */
+      virtual ~StaticLoadBalancer() {};
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal StaticLoadBalancer.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/SLB4MPI/SLB4MPI/static_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/static_load_balancer.hpp
@@ -24,7 +24,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      StaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      StaticLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of StaticLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/work_stealing_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/work_stealing_load_balancer.hpp
@@ -13,10 +13,10 @@ namespace SLB4MPI {
     private:
       int64_t counter;
 #ifdef SLB4MPI_WITH_MPI
-      MPI_win window_num_active;  ///< number of active threads
-      MPI_win window_bounds;      ///< lower and upper bounds of rank
-      MPI_win window_actual_rank; ///< actual rank to compute (for fast look up)
-      MPI_win window_done;        ///< status of thread
+      MPI_Win window_num_active;  ///< number of active threads
+      MPI_Win window_bounds;      ///< lower and upper bounds of rank
+      MPI_Win window_actual_rank; ///< actual rank to compute (for fast look up)
+      MPI_Win window_done;        ///< status of thread
       int actual_rank;            ///< rank for computing
       bool done;                  ///< does it compute all elements in its own rank? Implemented for non-blocking check with MPI_LOCK_SHARED
 #endif
@@ -32,7 +32,7 @@ namespace SLB4MPI {
        * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
        *
        */
-      WorkStealingLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      WorkStealingLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
       /**
        *
        * @brief d-tor of WorkStealingLoadBalancer

--- a/src/CXX/SLB4MPI/SLB4MPI/work_stealing_load_balancer.hpp
+++ b/src/CXX/SLB4MPI/SLB4MPI/work_stealing_load_balancer.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#ifdef SLB4MPI_WORK_STEALING_LB
+#  error "SLB4MPI_WORK_STEALING_LB was previously defined"
+#else
+#  define SLB4MPI_WORK_STEALING_LB
+#endif
+
+#include "abstract_load_balancer.hpp"
+
+namespace SLB4MPI {
+  class WorkStealingLoadBalancer final : public AbstractLoadBalancer {
+    private:
+      int64_t counter;
+#ifdef SLB4MPI_WITH_MPI
+      MPI_win window_num_active;  ///< number of active threads
+      MPI_win window_bounds;      ///< lower and upper bounds of rank
+      MPI_win window_actual_rank; ///< actual rank to compute (for fast look up)
+      MPI_win window_done;        ///< status of thread
+      int actual_rank;            ///< rank for computing
+      bool done;                  ///< does it compute all elements in its own rank? Implemented for non-blocking check with MPI_LOCK_SHARED
+#endif
+    public:
+      /**
+       *
+       * @brief initialize values of work stealing load balancer
+       *
+       * @param[in]           communicator   - MPI communicator on which load balancer will be used
+       * @param[in]           lower_bound    - lower bound of range
+       * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+       * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+       * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+       *
+       */
+      WorkStealingLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size = 1, const int64_t max_chunk_size = -1);
+      /**
+       *
+       * @brief d-tor of WorkStealingLoadBalancer
+       *
+       */
+      virtual ~WorkStealingLoadBalancer();
+      /**
+       *
+       * @brief get range to compute
+       * @note upper_bound can be only less than or equal WorkStealingLoadBalancer.upper_bound
+       *       so, for last elements a batch with size less than min_chunk_size can be returned
+       *
+       * @param[out] lower_bound - lower bound of range to compute
+       * @param[out] upper_bound - upper bound of range to compute
+       * @return                 - is there something to compute?
+       *
+       */
+      virtual bool get_range(int64_t&, int64_t&);
+  };
+}

--- a/src/CXX/abstract_load_balancer.cxx
+++ b/src/CXX/abstract_load_balancer.cxx
@@ -1,0 +1,41 @@
+#include <SLB4MPI/abstract_load_balancer.hpp>
+
+#include <cstdlib>
+#include <algorithm>
+
+/**
+ *
+ * @brief initialize default values of abstract load balancer
+ *
+ * @param[in]           communicator   - MPI communicator on which load balancer will be used
+ * @param[in]           lower_bound    - lower bound of range
+ * @param[in]           upper_bound    - upper bound of range, upper_bound >= lower_bound
+ * @param[in, optional] min_chunk_size - minimal size of chank that can be associated with job, default: 1
+ * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
+ *
+ */
+SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) {
+  this->communicator = communicator;
+  this->rank = 0;
+  this->nranks = 1;
+  this->root = 0;
+
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Comm_rank(this->communicator, &(this->rank));
+  MPI_Comm_size(this->communicator, &(this->nranks));
+#endif
+
+  this->lower_bound = lower_bound;
+  this->upper_bound = upper_bound;
+
+  this->min_chunk_size = min_chunk_size;
+  this->max_chunk_size = max_chunk_size;
+  if (this->max_chunk_size < 0) {
+    this->max_chunk_size = std::max((this->upper_bound - this->lower_bound + 1) / this->nranks, this->min_chunk_size);
+  }
+
+  if (this->min_chunk_size <= 0) std::exit(1); // "Min chunk size must be greater than zero!"
+
+  if (this->lower_bound > this->upper_bound) std::exit(1); // "Upper bound is less than lower bound!"
+  if (this->min_chunk_size > this->max_chunk_size) std::exit(1); // "Max chunk size is less than min chunk size!"
+}

--- a/src/CXX/abstract_load_balancer.cxx
+++ b/src/CXX/abstract_load_balancer.cxx
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <algorithm>
+#include <iostream>
 
 /**
  *
@@ -34,8 +35,18 @@ SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(const int communicator, cons
     this->max_chunk_size = std::max((this->upper_bound - this->lower_bound + 1) / this->nranks, this->min_chunk_size);
   }
 
-  if (this->min_chunk_size <= 0) std::exit(1); // "Min chunk size must be greater than zero!"
+  if (this->min_chunk_size <= 0) {
+    std::cerr << "Min chunk size must be greater than zero!" << std::endl;
+    std::exit(1);
+  }
 
-  if (this->lower_bound > this->upper_bound) std::exit(1); // "Upper bound is less than lower bound!"
-  if (this->min_chunk_size > this->max_chunk_size) std::exit(1); // "Max chunk size is less than min chunk size!"
+  if (this->lower_bound > this->upper_bound) {
+    std::cerr << "Upper bound is less than lower bound!" << this->lower_bound << " " << this->upper_bound << std::endl;
+    std::exit(1);
+  }
+
+  if (this->min_chunk_size > this->max_chunk_size) {
+    std::cerr << "Max chunk size is less than min chunk size!" << std::endl;
+    std::exit(1);
+  }
 }

--- a/src/CXX/abstract_load_balancer.cxx
+++ b/src/CXX/abstract_load_balancer.cxx
@@ -15,7 +15,7 @@
  * @param[in, optional] max_chunk_size - maximal size of chank that can be associated with job, default: upper_bound - lower_bound + 1
  *
  */
-SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) {
+SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) {
   this->communicator = communicator;
   this->rank = 0;
   this->nranks = 1;

--- a/src/CXX/dynamic_load_balancer.cxx
+++ b/src/CXX/dynamic_load_balancer.cxx
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-SLB4MPI::DynamicLoadBalancer::DynamicLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+SLB4MPI::DynamicLoadBalancer::DynamicLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
   this->counter = this->lower_bound;
 

--- a/src/CXX/dynamic_load_balancer.cxx
+++ b/src/CXX/dynamic_load_balancer.cxx
@@ -1,0 +1,37 @@
+#include <SLB4MPI/dynamic_load_balancer.hpp>
+
+#include <algorithm>
+
+SLB4MPI::DynamicLoadBalancer::DynamicLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  this->counter = this->lower_bound;
+
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_create(&counter, sizeof(counter), sizeof(counter), MPI_INFO_NULL, this->communicator, &(this->window));
+  MPI_Barrier(this->communicator);
+#endif
+}
+
+SLB4MPI::DynamicLoadBalancer::~DynamicLoadBalancer() {
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_free(&(this->window));
+#endif
+}
+
+bool SLB4MPI::DynamicLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_lock(MPI_LOCK_EXCLUSIVE, this->root, 0, this->window);
+  MPI_Fetch_and_op(&(this->min_chunk_size), &lower_bound, MPI_INT64_T, this->root, 0, MPI_SUM, this->window);
+  MPI_Win_unlock(this->root, this->window);
+#else
+  lower_bound = this->counter;
+  this->counter = this->counter + this->min_chunk_size;
+#endif
+
+  upper_bound = std::min(lower_bound + this->min_chunk_size - 1, this->upper_bound);
+
+  bool to_compute = true;
+  if (lower_bound > this->upper_bound) to_compute = false;
+  return to_compute;
+}

--- a/src/CXX/guided_load_balancer.cxx
+++ b/src/CXX/guided_load_balancer.cxx
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-SLB4MPI::GuidedLoadBalancer::GuidedLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+SLB4MPI::GuidedLoadBalancer::GuidedLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
   this->counter = this->lower_bound;
 

--- a/src/CXX/guided_load_balancer.cxx
+++ b/src/CXX/guided_load_balancer.cxx
@@ -1,0 +1,43 @@
+#include <SLB4MPI/guided_load_balancer.hpp>
+
+#include <algorithm>
+
+SLB4MPI::GuidedLoadBalancer::GuidedLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  this->counter = this->lower_bound;
+
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_create(&counter, sizeof(counter), sizeof(counter), MPI_INFO_NULL, this->communicator, &(this->window));
+  MPI_Barrier(this->communicator);
+#endif
+}
+
+SLB4MPI::GuidedLoadBalancer::~GuidedLoadBalancer() {
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_free(&(this->window));
+#endif
+}
+
+bool SLB4MPI::GuidedLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+  int64_t associated_tasks = 0;
+  int64_t root_counter = 0;
+
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_lock(MPI_LOCK_EXCLUSIVE, this->root, 0, this->window);
+  MPI_Get(&root_counter, 1, MPI_INT64_T, this->root, 0, 1, MPI_INT64_T, this->window);
+  MPI_Win_flush(this->root, this->window);
+  associated_tasks = std::min(std::max((this->upper_bound - root_counter) / this->nranks, this->min_chunk_size), this->max_chunk_size);
+  MPI_Fetch_and_op(&associated_tasks, &lower_bound, MPI_INT64_T, this->root, 0, MPI_SUM, this->window);
+  MPI_Win_unlock(this->root, this->window);
+#else
+  lower_bound = this->counter;
+  associated_tasks = std::min(std::max(this->upper_bound - this->counter, this->min_chunk_size), this->max_chunk_size);
+  this->counter += associated_tasks;
+#endif
+
+  upper_bound = std::min(lower_bound + associated_tasks - 1, this->upper_bound);
+
+  bool to_compute = true;
+  if (lower_bound > this->upper_bound) to_compute = false;
+  return to_compute;
+}

--- a/src/CXX/local_static_load_balancer.cxx
+++ b/src/CXX/local_static_load_balancer.cxx
@@ -1,0 +1,36 @@
+#include <SLB4MPI/local_static_load_balancer.hpp>
+
+#include <algorithm>
+
+SLB4MPI::LocalStaticLoadBalancer::LocalStaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  int64_t n_tasks = (upper_bound - lower_bound + 1) / this->nranks;
+  int64_t extra_tasks = (upper_bound - lower_bound + 1) % this->nranks;
+  if (n_tasks < min_chunk_size) {
+    n_tasks = min_chunk_size;
+    extra_tasks = 0;
+  }
+
+  if (this->rank < extra_tasks) {
+    this->lower_bound = this->rank * (n_tasks + 1) + lower_bound;
+    this->upper_bound = (this->rank + 1) * (n_tasks + 1) + lower_bound - 1;
+  } else {
+    this->lower_bound = this->rank * n_tasks + extra_tasks + lower_bound;
+    this->upper_bound = (this->rank + 1) * n_tasks + extra_tasks + lower_bound - 1;
+  }
+
+  this->lower_bound = std::min(this->lower_bound, upper_bound + 1);
+  this->upper_bound = std::min(this->upper_bound, upper_bound);
+
+  this->counter = this->lower_bound;
+}
+
+bool SLB4MPI::LocalStaticLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+  lower_bound = this->counter;
+  upper_bound = std::min(lower_bound + this->max_chunk_size - 1, this->upper_bound);
+  this->counter = upper_bound + 1;
+
+  bool to_compute = true;
+  if (lower_bound > this->upper_bound) to_compute = false;
+  return to_compute;
+}

--- a/src/CXX/local_static_load_balancer.cxx
+++ b/src/CXX/local_static_load_balancer.cxx
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-SLB4MPI::LocalStaticLoadBalancer::LocalStaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+SLB4MPI::LocalStaticLoadBalancer::LocalStaticLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
   int64_t n_tasks = (upper_bound - lower_bound + 1) / this->nranks;
   int64_t extra_tasks = (upper_bound - lower_bound + 1) % this->nranks;

--- a/src/CXX/runtime_load_balancer.cxx
+++ b/src/CXX/runtime_load_balancer.cxx
@@ -1,0 +1,81 @@
+#include <SLB4MPI/runtime_load_balancer.hpp>
+#include <SLB4MPI.hpp>
+
+#include <iostream>
+#include <cstdlib>
+#include <memory>
+
+SLB4MPI::RuntimeLoadBalancer::RuntimeLoadBalancer(const std::string& lbtype, const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  enum class LBType { env, rb_static, local_static, dynamic, guided, work_stealing, unknown };
+  LBType lbtypeid = LBType::env;
+  bool isenv = false;
+  std::string envval = std::string();
+  if (lbtype == std::string("env")) {
+    isenv = true;
+    char const* Cenvval = std::getenv("SLB4MPI_LOAD_BALANCER");
+    envval = Cenvval == nullptr ? std::string() : std::string(Cenvval);
+    if (envval == std::string() || envval == std::string("static")) {
+      lbtypeid = LBType::rb_static;
+    } else if (envval == std::string("local_static")) {
+      lbtypeid = LBType::local_static;
+    } else if (envval == std::string("dynamic")) {
+      lbtypeid = LBType::dynamic;
+    } else if (envval == std::string("guided")) {
+      lbtypeid = LBType::guided;
+    } else if (envval == std::string("work_stealing")) {
+      lbtypeid = LBType::work_stealing;
+    } else {
+      lbtypeid = LBType::unknown;
+    }
+  } else if (lbtype == std::string("static")) {
+    lbtypeid = LBType::rb_static;
+  } else if (lbtype == std::string("local_static")) {
+    lbtypeid = LBType::local_static;
+  } else if (lbtype == std::string("dynamic")) {
+    lbtypeid = LBType::dynamic;
+  } else if (lbtype == std::string("guided")) {
+    lbtypeid = LBType::guided;
+  } else if (lbtype == std::string("work_stealing")) {
+    lbtypeid = LBType::work_stealing;
+  } else {
+    lbtypeid = LBType::unknown;
+  }
+
+  switch(lbtypeid) {
+    case LBType::rb_static:
+      this->lb = std::make_unique<StaticLoadBalancer>(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size);
+      break;
+    case LBType::local_static:
+      this->lb = std::make_unique<LocalStaticLoadBalancer>(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size);
+      break;
+    case LBType::dynamic:
+      this->lb = std::make_unique<DynamicLoadBalancer>(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size);
+      break;
+    case LBType::guided:
+      this->lb = std::make_unique<GuidedLoadBalancer>(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size);
+      break;
+    case LBType::work_stealing:
+      this->lb = std::make_unique<WorkStealingLoadBalancer>(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size);
+      break;
+    case LBType::env:
+      // must never happen
+      std::cerr << "EnvLoadBalancer" << std::endl;
+      std::exit(1);
+      break;
+    case LBType::unknown:
+      if (isenv) {
+        std::cerr << "Unknown runtime load balancer taken from environmnent: '" << envval << "'!" << std::endl;
+        std::cerr << "Please, check SLB4MPI_LOAD_BALANCER environmental variable!" << std::endl;
+        std::cerr << "Possible values are: static, local_static, dynamic, guided, workstealing." << std::endl;
+      } else {
+        std::cerr << "Unknown runtime load balancer: '" << lbtype << "'!" << std::endl;
+      }
+      std::exit(1);
+      break;
+  }
+}
+
+bool SLB4MPI::RuntimeLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+  return this->lb->get_range(lower_bound, upper_bound);
+}

--- a/src/CXX/runtime_load_balancer.cxx
+++ b/src/CXX/runtime_load_balancer.cxx
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <memory>
 
-SLB4MPI::RuntimeLoadBalancer::RuntimeLoadBalancer(const std::string& lbtype, const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+SLB4MPI::RuntimeLoadBalancer::RuntimeLoadBalancer(const std::string& lbtype, const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
   enum class LBType { env, rb_static, local_static, dynamic, guided, work_stealing, unknown };
   LBType lbtypeid = LBType::env;

--- a/src/CXX/static_load_balancer.cxx
+++ b/src/CXX/static_load_balancer.cxx
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-SLB4MPI::StaticLoadBalancer::StaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+SLB4MPI::StaticLoadBalancer::StaticLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
   this->counter = this->lower_bound + this->rank * this->max_chunk_size;
 }

--- a/src/CXX/static_load_balancer.cxx
+++ b/src/CXX/static_load_balancer.cxx
@@ -1,0 +1,18 @@
+#include <SLB4MPI/static_load_balancer.hpp>
+
+#include <algorithm>
+
+SLB4MPI::StaticLoadBalancer::StaticLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  this->counter = this->lower_bound + this->rank * this->max_chunk_size;
+}
+
+bool SLB4MPI::StaticLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+  lower_bound = this->counter;
+  upper_bound = std::min(lower_bound + this->max_chunk_size - 1, this->upper_bound);
+  this->counter += this->max_chunk_size * this->nranks;
+
+  bool to_compute = true;
+  if (lower_bound > this->upper_bound) to_compute = false;
+  return to_compute;
+}

--- a/src/CXX/work_stealing_load_balancer.cxx
+++ b/src/CXX/work_stealing_load_balancer.cxx
@@ -1,0 +1,160 @@
+#include <SLB4MPI/work_stealing_load_balancer.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+SLB4MPI::WorkStealingLoadBalancer::WorkStealingLoadBalancer(const int communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
+  SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
+  int64_t n_tasks = (upper_bound - lower_bound + 1) / this->nranks;
+  int64_t extra_tasks = (upper_bound - lower_bound + 1) % this->nranks;
+  if (n_tasks < min_chunk_size) {
+    n_tasks = min_chunk_size;
+    extra_tasks = 0;
+  }
+
+  if (this->rank < extra_tasks) {
+    this->lower_bound = this->rank * (n_tasks + 1) + lower_bound;
+    this->upper_bound = (this->rank + 1) * (n_tasks + 1) + lower_bound - 1;
+  } else {
+    this->lower_bound = this->rank * n_tasks + extra_tasks + lower_bound;
+    this->upper_bound = (this->rank + 1) * n_tasks + extra_tasks + lower_bound - 1;
+  }
+
+  this->lower_bound = std::min(this->lower_bound, upper_bound + 1);
+  this->upper_bound = std::min(this->upper_bound, upper_bound);
+
+  this->counter = this->lower_bound;
+
+#ifdef SLB4MPI_WITH_MPI
+  this->actual_rank = this->rank;
+  this->done = false;
+
+  void * baseaddr_num_active, baseaddr_bounds;
+
+  MPI_Win_allocate(sizeof(int), sizeof(int), MPI_INFO_NULL, this->communicator, baseaddr_num_active, &(this->window_num_active));
+  MPI_Win_create(&(this->actual_rank), sizeof(int), sizeof(int), MPI_INFO_NULL, this->communicator, &(this->window_actual_rank));
+  MPI_Win_allocate(2*sizeof(int64_t), sizeof(int64_t), MPI_INFO_NULL, this->communicator, baseaddr_bounds, &(this->window_bounds));
+  MPI_Win_create(&(this->done), sizeof(bool), sizeof(bool), MPI_INFO_NULL, this->communicator, &(this->window_done));
+
+  if (this->rank == this->root) {
+    int* num_active = static_cast<int*>(baseaddr_num_active);
+    *num_active = this->nranks;
+  }
+  std::array<int64_t,2> * bounds = static_cast<std::array<int64_t,2>*>(baseaddr_bounds);
+  (*bounds)[0] = this->lower_bound;
+  (*bounds)[1] = this->upper_bound;
+
+  MPI_Barrier(this->communicator);
+#endif
+}
+
+SLB4MPI::WorkStealingLoadBalancer::~WorkStealingLoadBalancer() {
+#ifdef SLB4MPI_WITH_MPI
+  MPI_Win_free(&(this->window_num_active));
+  MPI_Win_free(&(this->window_actual_rank));
+  MPI_Win_free(&(this->window_bounds));
+  MPI_Win_free(&(this->window_done));
+#endif
+}
+
+bool SLB4MPI::WorkStealingLoadBalancer::get_range(int64_t& lower_bound, int64_t& upper_bound) {
+
+#ifndef SLB4MPI_WITH_MPI
+
+  lower_bound = this->counter;
+  upper_bound = std::min(lower_bound + this->max_chunk_size - 1, this->upper_bound);
+  this->counter = upper_bound + 1;
+
+  bool to_compute = false;
+  if (lower_bound <= this->upper_bound) to_compute = true;
+  return to_compute;
+
+#else
+  std::array<int64_t, 2> bounds;
+  bool to_compute = false;
+
+  if (this->actual_rank == this->rank) {
+    to_compute = true;
+    // select range for computing
+    MPI_Win_lock(MPI_LOCK_EXCLUSIVE, this->rank, 0, this->window_bounds);
+    MPI_Get(&bounds, 2, MPI_INT64_T, this->rank, 0, 2, MPI_INT64_T, this->window_bounds);
+    MPI_Win_flush(this->rank, this->window_bounds);
+    this->lower_bound = bound[0];
+    this->upper_bound = bound[1];
+    lower_bound = this->lower_bound;
+    upper_bound = std::min(lower_bound + this->max_chunk_size - 1, this->upper_bound);
+    bounds[0] = upper_bound + 1;
+    // update lower bound
+    MPI_Accumulate(&bounds, 2, MPI_INT64_T, this->rank, 0, 2, MPI_INT64_T, MPI_REPLACE, this->window_bounds);
+    MPI_Win_unlock(this->rank, this->window_bounds);
+    // if it the last block, give that information in advance
+    if (upper_bound + 1 > this->upper_bound && !this->done) {
+      MPI_Win_lock(MPI_LOCK_EXCLUSIVE, this->root, 0, this->window_num_active);
+      int minus_one = -1;
+      MPI_Fetch_and_op(&minus_one, &num_active, MPI_INT, this->root, 0, MPI_SUM, this->window_num_active);
+      MPI_Win_unlock(this->root, this->window_num_active);
+      this->actual_rank = (this->actual_rank + 1) % this->nranks;
+      this->done = true;
+    }
+    if (lower_bound > upper_bound) to_compute = false;
+  }
+
+  // switch to other ranks
+  int hop_count = 0, nohop_count = 0;
+  while (!to_compute) {
+    int compute_rank;
+    bool done;
+    std::array<int64_t, 2> bounds;
+    // get rank which computes lb%actual_rank
+    MPI_Win_lock(MPI_LOCK_SHARED, this->actual_rank, MPI_MODE_NOCHECK, this->window_actual_rank);
+    MPI_Get(&compute_rank, 1, MPI_INT, this->actual_rank, 0, 1, MPI_INT, this->window_actual_rank);
+    MPI_Win_unlock(this->actual_rank, this->window_actual_rank);
+    // check that compute_rank computes itself
+    if (lb%actual_rank == compute_rank) {
+      // check that there is something to steal
+      MPI_Win_lock(MPI_LOCK_SHARED, this->actual_rank, MPI_MODE_NOCHECK, this->window_done);
+      MPI_Get(done, 1, MPI_CXX_BOOL, this->actual_rank, 0, 1, MPI_CXX_BOOL, this->window_done);
+      MPI_Win_unlock(this->actual_rank, this->window_done);
+      if (!done) {
+        // try to steal min_chunk_size jobs from compute_rank
+        MPI_Win_lock(MPI_LOCK_EXCLUSIVE, compute_rank, 0, this->window_bounds);
+        MPI_Get(&bounds, 2, MPI_INT64_T, compute_rank, 0, 2, MPI_INT64_T, this->window_bounds);
+        MPI_Win_flush(compute_rank, this->window_bounds);
+        upper_bound = bounds[1];
+        lower_bound = std::max(bounds[0], bounds[1] - this->min_chunk_size + 1);
+        bounds[1] = lower_bound - 1;
+        if (lower_bound <= upper_bound) to_compute = true;
+        if (to_compute) {
+          // update upper bound
+          call MPI_Accumulate(&bounds, 2, MPI_INT64_T, compute_rank, 0, 2, MPI_INT64_T, MPI_REPLACE, this->window_bounds);
+        }
+        MPI_Win_unlock(compute_rank, this->window_bounds);
+        if (to_compute) return to_compute;
+      }
+    } else {
+      // switch to lb%actual_rank of compute_rank
+      this->actual_rank = compute_rank;
+      if (lb%actual_rank == lb%rank) return false;
+      // but... to avoid infinity cycle, sometimes we will check that there is some jobs
+      hop_count = hop_count + 1;
+      {
+        float randval = rand();
+        // log(nranks) <- how often to check cond (each 1, 2, 3, ..)
+        // 1 / log(nranks) <- probability
+        if (randval > (1. / std::log(static_cast<float>(this->nranks))) && hop_count < 20) continue;
+      }
+    }
+    // if could not steal job, check how many threads finished job
+    int num_active;
+    MPI_Win_lock(MPI_LOCK_SHARED, this->root, 0, this->window_num_active);
+    MPI_Get(&num_active, 1, MPI_INT, this->root, 0, 1, MPI_INT, this->window_num_active);
+    MPI_Win_unlock(this->root, this->window_num_active);
+    if (num_active == 0) return false;
+    this->actual_rank = (this->actual_rank + 1) % this->nranks;
+    hop_count = 0;
+    nohop_count = nohop_count + 1;
+    if (nohop_count > lb%nranks) return false;
+  }
+#endif
+}

--- a/src/CXX/work_stealing_load_balancer.cxx
+++ b/src/CXX/work_stealing_load_balancer.cxx
@@ -68,7 +68,6 @@ bool SLB4MPI::WorkStealingLoadBalancer::get_range(int64_t& lower_bound, int64_t&
 
   bool to_compute = false;
   if (lower_bound <= this->upper_bound) to_compute = true;
-  return to_compute;
 
 #else
   std::array<int64_t, 2> bounds;
@@ -157,6 +156,6 @@ bool SLB4MPI::WorkStealingLoadBalancer::get_range(int64_t& lower_bound, int64_t&
     nohop_count = nohop_count + 1;
     if (nohop_count > this->nranks) return false;
   }
-  return false;
 #endif
+  return to_compute;
 }

--- a/src/CXX/work_stealing_load_balancer.cxx
+++ b/src/CXX/work_stealing_load_balancer.cxx
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <random>
 
 SLB4MPI::WorkStealingLoadBalancer::WorkStealingLoadBalancer(const MPI_Comm communicator, const int64_t lower_bound, const int64_t upper_bound, const int64_t min_chunk_size, const int64_t max_chunk_size) :
   SLB4MPI::AbstractLoadBalancer::AbstractLoadBalancer(communicator, lower_bound, upper_bound, min_chunk_size, max_chunk_size) {
@@ -143,7 +144,10 @@ bool SLB4MPI::WorkStealingLoadBalancer::get_range(int64_t& lower_bound, int64_t&
       // but... to avoid infinity cycle, sometimes we will check that there is some jobs
       hop_count = hop_count + 1;
       {
-        float randval = 0.5;
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_real_distribution<> unif(0.0, 1.0);
+        float randval = unif(gen);
         // log(nranks) <- how often to check cond (each 1, 2, 3, ..)
         // 1 / log(nranks) <- probability
         if (randval > (1. / std::log(static_cast<float>(this->nranks))) && hop_count < 20) continue;


### PR DESCRIPTION
Currently, C++ work stealing load balancer does not work with OpenMPI 4.1.1 and OpenMPI 4.1.2. With 5.0.5 it works.